### PR TITLE
Dont recreate ini on restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@ MAX_PLAYERS=6
 # Set to false to skip updating server files on container start
 UPDATE_ON_START=true
 
+# Set to true regenerate the DedicatedServer.ini on restarts
+REGENERATE_SERVER_INI_ON_RESTART=false
+

--- a/README.md
+++ b/README.md
@@ -71,18 +71,19 @@ docker run -d \
 
 ## Environment Variables
 
-| Variable           | Default            | Info                                                                                      |
-|--------------------|--------------------|-------------------------------------------------------------------------------------------|
-| PUID               | 1000               | User ID for file permissions                                                              |
-| PGID               | 1000               | Group ID for file permissions                                                             |
-| UPDATE_ON_START    | true               | If set to false, skips downloading and validating server files on startup                 |
-| OWNER_ID           |                    | **Required.** Your RuneScape: DragonWilds Player ID (found in Settings Menu in-game)     |
-| SERVER_NAME        | DragonWildsServer  | Display name of the server                                                                |
-| DEFAULT_WORLD_NAME | MyWorld            | Name of the default world created on first startup                                        |
-| ADMIN_PASSWORD     |                    | **Required.** Password to access Server Management in-game                               |
-| WORLD_PASSWORD     |                    | Optional join password. Leave empty for a public server                                   |
-| DEFAULT_PORT       | 7777               | The UDP port the server listens on                                                        |
-| MAX_PLAYERS        | 6                  | Maximum number of players allowed on the server                                           |
+| Variable                | Default            | Info                                                                                        |
+|-------------------------|--------------------|---------------------------------------------------------------------------------------------|
+| PUID                    | 1000               | User ID for file permissions                                                                |
+| PGID                    | 1000               | Group ID for file permissions                                                               |
+| UPDATE_ON_START         | true               | If set to false, skips downloading and validating server files on startup                   |
+| OWNER_ID                |                    | **Required.** Your RuneScape: DragonWilds Player ID (found in Settings Menu in-game)        |
+| SERVER_NAME             | DragonWildsServer  | Display name of the server                                                                  |
+| DEFAULT_WORLD_NAME      | MyWorld            | Name of the default world created on first startup                                          |
+| ADMIN_PASSWORD          |                    | **Required.** Password to access Server Management in-game                                  |
+| WORLD_PASSWORD          |                    | Optional join password. Leave empty for a public server                                     |
+| DEFAULT_PORT            | 7777               | The UDP port the server listens on                                                          |
+| MAX_PLAYERS             | 6                  | Maximum number of players allowed on the server                                             |
+| REGENERATE_INI_ON_START | false              | If set to false, skips regenerating the server ini and resetting the ServerGuid ans players |
 
 > [!NOTE]
 > If your server doesn't appear, check that UDP port 7777 is forwarded through your firewall/router and that `OWNER_ID` and `ADMIN_PASSWORD` are set.

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -32,12 +32,12 @@ if [ -z "${OWNER_ID}" ]; then
     exit 1
 fi
 
-CONFIG_DIR="/home/steam/server-files/RSDragonwilds/Saved/Config/LinuxServer"
-CONFIG_FILE="$CONFIG_DIR/DedicatedServer.ini"
-
-mkdir -p "$CONFIG_DIR"
-LogInfo "Writing DedicatedServer.ini"
-envsubst > "$CONFIG_FILE" << 'TEMPLATE'
+generate_server_ini_on_load() {
+    local config_file="$1"
+    local config_dir="$2"
+    mkdir -p "$config_dir"
+    LogInfo "Writing DedicatedServer.ini"
+    envsubst > "$config_file" << 'TEMPLATE'
 [SectionsToSave]
 bCanSaveAllSections=true
 
@@ -49,7 +49,19 @@ ServerName=${SERVER_NAME}
 DefaultWorldName=${DEFAULT_WORLD_NAME}
 ServerGuid=
 TEMPLATE
-chown steam:steam "$CONFIG_FILE"
+    chown steam:steam "$config_file"
+}
+
+CONFIG_DIR="/home/steam/server-files/RSDragonwilds/Saved/Config/LinuxServer"
+CONFIG_FILE="$CONFIG_DIR/DedicatedServer.ini"
+
+# On reload check REGENERATE_SERVER_INI_ON_RESTART if we should generate the ini file
+# Will always generate the DedicatedServer.ini if it doesn't exist ie on the first start
+if [ ! -f "$CONFIG_FILE" ] || [ "${REGENERATE_SERVER_INI_ON_RESTART:-false}" = "true" ]; then
+    generate_server_ini_on_load "$CONFIG_FILE" "$CONFIG_DIR"
+else
+    LogInfo "DedicatedServer.ini already exists, skipping regeneration"
+fi
 
 # shellcheck disable=SC2317
 term_handler() {


### PR DESCRIPTION
Adding env var (`REGENERATE_SERVER_INI_ON_RESTART` default false) to control if we should regenerate the server ini on restarts.
We will always regenerate the ini if it does not exit for example on first setup or if the user deletes it.